### PR TITLE
Response parsing

### DIFF
--- a/tests/cases/extensions/adapter/data/source/http/CharizardTest.php
+++ b/tests/cases/extensions/adapter/data/source/http/CharizardTest.php
@@ -109,11 +109,11 @@ class CharizardTest extends Unit {
 				array('foo', 'bar', 'baz'),
 				array(
 					'stats' => array(
-						'count' => 1234,
-						'facets' => array(),
-						'facet_counts' => array(),
 						'matches' => 1234,
 						'ngroups' => 5678,
+						'count' => 5678, //1234
+						'facet_counts' => array(),
+						'facets' => array(),
 					),
 					'class' => 'set',
 				)


### PR DESCRIPTION
Added existing result parsing logic from mdx_search and mdx_solr. Should handle different groups and non-grouped queries now. I'm guessing this also makes facets work...
