### PR TITLE
Add work-around for responses that are already decoded.

### DIFF
--- a/extensions/adapter/data/source/http/Charizard.php
+++ b/extensions/adapter/data/source/http/Charizard.php
@@ -135,7 +135,7 @@ class Charizard extends Http {
 	 * @return array Solr response
 	 */
 	protected function parseRaw($response) {
-		$parsed = json_decode($response, true);
+		$parsed = is_array($response) ? $response : json_decode($response, true);
 		if (!is_array($parsed) || empty($parsed['responseHeader'])) {
 			throw new QueryException('Failed to read Solr response: `' . var_export($response, true) . '`.');
 		}


### PR DESCRIPTION
When the response type is ajax, rather than plain text, the response is
already json decoded. I'm guessing this happens somewhere in the li3
response processing, but I don't know where that behavior could be
easily changed yet. This is a simple work-around for those cases.

This was happening when talking to the solr core admin api.
