### PR TITLE
Bypass response decoding bug in li3.

### DIFF
--- a/extensions/net/http/RawResponse.php
+++ b/extensions/net/http/RawResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace li3_charizard\extensions\net\http;
+
+class RawResponse extends \lithium\net\http\Response {
+
+	// Per RFC 2397 data urls should be url-escaped or base64 encoded.
+	// The base li3 implementation resulted in body's having url-escaped
+	// values replaced with their normal character equivalents.
+	protected function _httpChunkedDecode($body) {
+		if (stripos($this->headers['Transfer-Encoding'], 'chunked') === false) {
+			return $body;
+		}
+		$stream = fopen('data://text/plain,' . urlencode($body), 'r');
+		stream_filter_append($stream, 'dechunk');
+		return trim(stream_get_contents($stream));
+	}
+
+}
+
+?>

--- a/extensions/net/http/RawService.php
+++ b/extensions/net/http/RawService.php
@@ -7,7 +7,7 @@ class RawService extends \lithium\net\http\Service {
 	protected $_classes = array(
 		'media'    => 'lithium\net\http\Media',
 		'request'  => 'li3_charizard\extensions\net\http\RawRequest',
-		'response' => 'lithium\net\http\Response'
+		'response' => 'li3_charizard\extensions\net\http\RawResponse',
 	);
 
 }


### PR DESCRIPTION
@#^$!(@*#$ lithium!!! Stop trying to be so fancy!

The data url is decoded which was replacing urlencoded characters in the body (e.g. a deliberately escaped string inside of serialized json).

_edit_: created ticket https://vitals.atlassian.net/browse/VIT-3101 to track this.
